### PR TITLE
download from multiple prior builds in a self contained script.

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -1,6 +1,6 @@
 # This action creates a dummy artifact, to be tested by the "test-download-artifacts" workflow.
 
-name: 'create-artifacts'
+name: "ci-test"
 
 on:
   pull_request:
@@ -9,7 +9,18 @@ on:
     branches: [master]
 
 jobs:
-  create-artifact:
+  shellcheck_actions:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Shellcheck action scritps
+        run: |
+          shellcheck get-artifacts/get_artifacts.sh &&
+          shellcheck changes/get_pr_info.sh
+
+  create-artifact-for-tests:
     runs-on: ubuntu-latest
     steps:
       - name: Create dummy artifacts

--- a/.github/workflows/test-download-artifacts.yml
+++ b/.github/workflows/test-download-artifacts.yml
@@ -5,7 +5,7 @@ name: "test-download-artifacts"
 
 on:
   workflow_run:
-    workflows: ["create-artifacts"]
+    workflows: ["ci-test"]
     types:
       - completed
 
@@ -61,7 +61,7 @@ jobs:
         uses: ./get-artifacts
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          workflow_file: create-artifacts.yml
+          workflow_file: ci-test.yml
           artifacts: test.download test.not-download
           branch: master
       - name: Test that "test.download" got downloaded

--- a/.github/workflows/test-download-artifacts.yml
+++ b/.github/workflows/test-download-artifacts.yml
@@ -33,7 +33,7 @@ jobs:
 
   test-get-artifacts-single:
     runs-on: ubuntu-latest
-    name: test get-artifacts single job
+    name: test get-artifacts from a single workflow run
     steps:
       - uses: actions/checkout@v2
       - name: Download and extract single run's artifacts.
@@ -42,30 +42,34 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           workflow_run_id: ${{ github.event.workflow_run.id }}
           artifacts: test.download
-          #these are defaults
+          # the following two lines are default values included for clarity.
           target_dir: ${{ github.workspace }}/downloads
           decompress: true
       - name: Test that "test.download" got downloaded
         run: |
           [[ -f  ${{ github.workspace }}/downloads/${{ github.event.workflow_run.id }}/test.download/test-file.download ]]
+          [ $( ls ${{ github.workspace }}/downloads/ | wc -l ) = 1 ]
       - name: Test that "test.not-download" did not get downloaded
         run: |
           [[ ! -f  ${{ github.workspace }}/downloads/${{ github.event.workflow_run.id }}/test.not-download/test-file.not-download ]]
 
   test-get-artifacts-multiple:
     runs-on: ubuntu-latest
-    name: test get-artifacts-multiple
+    name: test get-artifacts multiple workflow runs.
     steps:
       - uses: actions/checkout@v2
-      - name: Download and extract single run's artifacts.
+      - name: Download and extract artifacts from the last ten runs of ci-test.yml on the master branch.
         uses: ./get-artifacts
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           workflow_file: ci-test.yml
           artifacts: test.download test.not-download
+          # optional, otherwise all branches.
           branch: master
-      - name: Test that "test.download" got downloaded
+          # follow line is a default value included for clarity.
+          history: 10
+      - name: Test that multiple workflow run's files got downloaded
         run: |
           [[ -f ${{ github.workspace }}/downloads/${{ github.event.workflow_run.id }}/test.download/test-file.download ]]
           [[ -f ${{ github.workspace }}/downloads/${{ github.event.workflow_run.id }}/test.not-download/test-file.not-download ]]
-          [[ $( ls -l ${{ github.workspace }}/downloads/ | wc -l ) -gt 1 ]]
+          [ $( ls ${{ github.workspace }}/downloads/ | wc -l ) -gt 1 ]

--- a/get-artifacts/README.md
+++ b/get-artifacts/README.md
@@ -1,14 +1,16 @@
 # Get Artifacts #
 
-A downloader for artifacts from multiple prior workflow_runs, or a single run by workflow_run_id.
+A downloader for artifacts from multiple prior workflow_runs (by workflow_file_name and branch), or a single run by workflow_run_id.
 
-Artifacts are always uploaded as zips, correspondingly this action allows you unzip and then delete the original downloads with the "decompress" flags.
+Artifacts are always uploaded as zips, correspondingly this action allows you to unzip and then delete the original downloads with the "decompress" flags.
 
-If a ```${{ inputs.target_dir }}/<workflow_run_id>``` folder already exist no attempt will be made to download the artifacts for that run.
+If an ```${{ inputs.target_dir }}/<workflow_run_id>/<artifact_name>/``` folder already exist no attempt will be made to download the artifacts for that run.  The assumption it github's cache action can be use to preserve prior downloads between workflow executions, preventing unnecessary downloads.  More info on cacheing [here](https://docs.github.com/en/actions/guides/caching-dependencies-to-speed-up-workflows "caching-dependencies-to-speed-up-workflows").
+
+## Examples ##
 
 Download artifacts from one workflow run.
 
-```
+```yaml
   test-get-artifacts-single:
     runs-on: ubuntu-latest
     name: test get-artifacts single job
@@ -20,7 +22,7 @@ Download artifacts from one workflow run.
           token: ${{ secrets.GITHUB_TOKEN }}
           workflow_run_id: ${{ github.event.workflow_run.id }}
           artifacts: test.download
-          #these are defaults
+          # the following lines are defaults included for clarity.
           target_dir: ${{ github.workspace }}/downloads
           decompress: true
       - name: Test that "test.download" got downloaded
@@ -31,9 +33,9 @@ Download artifacts from one workflow run.
           [[ ! -f  ${{ github.workspace }}/downloads/${{ github.event.workflow_run.id }}/test.not-download/test-file.not-download ]]
 ```
 
-Download artifacts from multiple workflow runs, newest to oldest by repo (optional, calculated), branch (optional, ignored), and workflow_file name (mandatory).
+Download artifacts from multiple workflow runs, newest to oldest by repo (optional, calculated), branch (optional, ignored), and workflow_file name (mandatory).  The workflow_file must be the full name of the workflow file in the .github/workflows/ directory.
 
-```
+```yaml
   test-get-artifacts-multiple:
     runs-on: ubuntu-latest
     name: test get-artifacts-multiple
@@ -46,7 +48,7 @@ Download artifacts from multiple workflow runs, newest to oldest by repo (option
           workflow_file: create-artifacts.yml
           artifacts: test.download test.not-download
           branch: master
-      - name: Test that "test.download" got downloaded
+      - name: Test that multiple jobs files got downloaded
         run: |
           [[ -f ${{ github.workspace }}/downloads/${{ github.event.workflow_run.id }}/test.download/test-file.download ]]
           [[ -f ${{ github.workspace }}/downloads/${{ github.event.workflow_run.id }}/test.not-download/test-file.not-download ]]

--- a/get-artifacts/README.md
+++ b/get-artifacts/README.md
@@ -13,7 +13,7 @@ Download artifacts from one workflow run.
 ```yaml
   test-get-artifacts-single:
     runs-on: ubuntu-latest
-    name: test get-artifacts single job
+    name: test get-artifacts from a single workflow run
     steps:
       - uses: actions/checkout@v2
       - name: Download and extract single run's artifacts.
@@ -22,12 +22,13 @@ Download artifacts from one workflow run.
           token: ${{ secrets.GITHUB_TOKEN }}
           workflow_run_id: ${{ github.event.workflow_run.id }}
           artifacts: test.download
-          # the following lines are defaults included for clarity.
+          # the following two lines are default values included for clarity.
           target_dir: ${{ github.workspace }}/downloads
           decompress: true
       - name: Test that "test.download" got downloaded
         run: |
           [[ -f  ${{ github.workspace }}/downloads/${{ github.event.workflow_run.id }}/test.download/test-file.download ]]
+          [ $( ls ${{ github.workspace }}/downloads/ | wc -l ) = 1 ]
       - name: Test that "test.not-download" did not get downloaded
         run: |
           [[ ! -f  ${{ github.workspace }}/downloads/${{ github.event.workflow_run.id }}/test.not-download/test-file.not-download ]]
@@ -38,19 +39,22 @@ Download artifacts from multiple workflow runs, newest to oldest by repo (option
 ```yaml
   test-get-artifacts-multiple:
     runs-on: ubuntu-latest
-    name: test get-artifacts-multiple
+    name: test get-artifacts multiple workflow runs.
     steps:
       - uses: actions/checkout@v2
-      - name: Download and extract single run's artifacts.
+      - name: Download and extract artifacts from the last ten runs of ci-test.yml on the master branch.
         uses: ./get-artifacts
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          workflow_file: create-artifacts.yml
+          workflow_file: ci-test.yml
           artifacts: test.download test.not-download
+          # optional, otherwise all branches.
           branch: master
-      - name: Test that multiple jobs files got downloaded
+          # follow line is a default value included for clarity.
+          history: 10
+      - name: Test that multiple workflow run's files got downloaded
         run: |
           [[ -f ${{ github.workspace }}/downloads/${{ github.event.workflow_run.id }}/test.download/test-file.download ]]
           [[ -f ${{ github.workspace }}/downloads/${{ github.event.workflow_run.id }}/test.not-download/test-file.not-download ]]
-          [[ $( ls -l ${{ github.workspace }}/downloads/ | wc -l ) -gt 1 ]]
+          [ $( ls ${{ github.workspace }}/downloads/ | wc -l ) -gt 1 ]
 ```

--- a/get-artifacts/README.md
+++ b/get-artifacts/README.md
@@ -1,10 +1,10 @@
 # Get Artifacts #
 
-A downloader for artifacts from multiple prior workflow_runs (by workflow_file_name and branch), or a single run by workflow_run_id.
+A downloader for artifacts from multiple prior workflow_runs (by workflow_file name, and branch), or a single run by workflow_run_id.  Instead of workflow_file name, a workflow_id name as described [here](https://docs.github.com/en/rest/reference/actions#list-workflow-runs "list-workflow-runs") may be passed, but please keep in mind if you use workflow_id name collisions may occur and you will recieve a mix of artifacts from different workflows.
 
 Artifacts are always uploaded as zips, correspondingly this action allows you to unzip and then delete the original downloads with the "decompress" flags.
 
-If an ```${{ inputs.target_dir }}/<workflow_run_id>/<artifact_name>/``` folder already exist no attempt will be made to download the artifacts for that run.  The assumption it github's cache action can be use to preserve prior downloads between workflow executions, preventing unnecessary downloads.  More info on cacheing [here](https://docs.github.com/en/actions/guides/caching-dependencies-to-speed-up-workflows "caching-dependencies-to-speed-up-workflows").
+If an ```${{ inputs.target_dir }}/<workflow_run_id>/<artifact_name>/``` folder already exists no attempt will be made to download the artifacts for that run.   This script runs is effectively idempotent provided there are no new workflow runs since it's last invocation.  The assumption is github's cache action can be use to preserve prior downloads between workflow executions, preventing unnecessary downloads should you need to implement a workflow with costly downloads.  More info on caching [here](https://docs.github.com/en/actions/guides/caching-dependencies-to-speed-up-workflows "caching-dependencies-to-speed-up-workflows").
 
 ## Examples ##
 
@@ -46,6 +46,7 @@ Download artifacts from multiple workflow runs, newest to oldest by repo (option
         uses: ./get-artifacts
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          # You may instead pass a workflow id rather than the workflow name, at your discression/peril.
           workflow_file: ci-test.yml
           artifacts: test.download test.not-download
           # optional, otherwise all branches.

--- a/get-artifacts/README.md
+++ b/get-artifacts/README.md
@@ -1,36 +1,14 @@
-# This action tests the "download-artifacts" action. Note that it runs on workflow_run events, so changes must
-# be checked into the main branch before they can be tested.
+# Get Artifacts #
 
-name: "test-download-artifacts"
+A downloader for artifacts from multiple prior workflow_runs, or a single run by workflow_run_id.
 
-on:
-  workflow_run:
-    workflows: ["create-artifacts"]
-    types:
-      - completed
+Artifacts are always uploaded as zips, correspondingly this action allows you unzip and then delete the original downloads with the "decompress" flags.
 
-jobs:
-  test-download-artifacts:
-    runs-on: ubuntu-latest
-    name: test download-artifacts
-    steps:
-      - uses: actions/checkout@v2
-      - name: Download and extract artifacts
-        uses: ./download-artifacts
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          run-id: ${{ github.event.workflow_run.id }}
-          pattern: '^.*\.download$'
-          extract: true
-      - name: Test that "test.download" got downloaded
-        run: |
-          [[ -f artifacts/test.download.zip ]]
-          cat artifacts/test.download/test-file.download
-      - name: Test that "test.not-download" did not get downloaded
-        run: |
-          [[ ! -f artifacts/test.not-download.zip ]]
-          [[ ! -f artifacts/test.not-download/test-file.not-download ]]
+If a ```${{ inputs.target_dir }}/<workflow_run_id>``` folder already exist no attempt will be made to download the artifacts for that run.
 
+Download artifacts from one workflow run.
+
+```
   test-get-artifacts-single:
     runs-on: ubuntu-latest
     name: test get-artifacts single job
@@ -51,7 +29,11 @@ jobs:
       - name: Test that "test.not-download" did not get downloaded
         run: |
           [[ ! -f  ${{ github.workspace }}/downloads/${{ github.event.workflow_run.id }}/test.not-download/test-file.not-download ]]
+```
 
+Download artifacts from multiple workflow runs, newest to oldest by repo (optional, calculated), branch (optional, ignored), and workflow_file name (mandatory).
+
+```
   test-get-artifacts-multiple:
     runs-on: ubuntu-latest
     name: test get-artifacts-multiple
@@ -69,3 +51,4 @@ jobs:
           [[ -f ${{ github.workspace }}/downloads/${{ github.event.workflow_run.id }}/test.download/test-file.download ]]
           [[ -f ${{ github.workspace }}/downloads/${{ github.event.workflow_run.id }}/test.not-download/test-file.not-download ]]
           [[ $( ls -l ${{ github.workspace }}/downloads/ | wc -l ) -gt 1 ]]
+```

--- a/get-artifacts/action.yml
+++ b/get-artifacts/action.yml
@@ -1,0 +1,57 @@
+name: "Get Artifacts"
+description: |
+  Get artifacts from either a single workflow_run, or from the latest workflow runs for a workflow/branch combo.
+  If a folder dedicated to holding a particular workflow_run's artifacts has already been constructed in the target output
+  folder, the artifacts for that build will not attempt to be downloaded then unzipped.
+inputs:
+  token:
+    description: github token, needed to access artifacts
+    required: true
+  target_dir:
+    default: ${{ github.workspace }}/downloads
+    description: The root folder to pull all artifact files in to (under a subfolder named for the workflow_run_id).
+    required: false
+  artifacts:
+    description: Space seperated names of artifacts to download.
+    required: true
+  repo:
+    default: ${{ github.repository }}
+    description: Target repo to pull artifacts from (defaults to current repo.) Should be in slug form (ie, diem/diem).
+    required: false
+  workflow_file:
+    description: The workflow filename used to find workflow job history. Not compatible with workflow_id.
+    required: false
+  branch:
+    description: The target branch to pull artifacts from (defaults to current branch).  Not compatible with workflow_id.
+    required: false
+  history:
+    description: The number of historic runs to gather artifacts from.
+    default: "10"
+    required: false
+  workflow_run_id:
+    description: A specific workflow execution to pull artifacts from.
+    required: false
+  decompress:
+    default: "true"
+    description: should artifacts be unzipped and original zips deleted
+    required: false
+runs:
+  using: "composite"
+  steps:
+    - run: |
+        extra_param=()
+        if [ "$DECOMPRESS" = "true" ]; then
+          extra_param+=("-z")
+        fi
+        ${GITHUB_ACTION_PATH}/get_artifacts.sh -d "$TARGET_DIR" -a "$ARTIFACTS" -w "$WORKFILE" -b "$BRANCH" -r "$REPOSITORY" -h "$HISTORY" -i "$WORKFLOW_RUN_ID" -t "${GITHUB_TOKEN}" "${extra_param[@]}"
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ inputs.token }}
+        TARGET_DIR: ${{ inputs.target_dir }}
+        ARTIFACTS: ${{ inputs.artifacts }}
+        REPOSITORY: ${{ inputs.repo }}
+        WORKFILE: ${{ inputs.workflow_file }}
+        BRANCH: ${{ inputs.branch }}
+        HISTORY: ${{ inputs.history }}
+        WORKFLOW_RUN_ID: ${{ inputs.workflow_run_id }}
+        DECOMPRESS: ${{ inputs.decompress }}

--- a/get-artifacts/get_artifacts.sh
+++ b/get-artifacts/get_artifacts.sh
@@ -1,0 +1,168 @@
+#!/bin/bash
+function echoerr() {
+  cat <<< "$@" 1>&2;
+}
+
+#Check prerequists.
+function check_command() {
+    for var in "$@"; do
+      if ! (command -v "$var" >/dev/null 2>&1); then
+          echoerr "This command requires $var to be installed"
+          exit 1
+      fi
+    done
+}
+check_command jq curl zip echo getopts
+
+function usage() {
+  echoerr -t token used to communicate with github actions.
+  echoerr -h number of workflow_runs to pull artifacts from.
+  echoerr -a space seperated list of artifact names.
+  echoerr -b optional branch to pull historical artifacts from.
+  echoerr -w workflow file name of of workflow to pull artifact from.
+  echoerr -d target directory where subdirectories for jobs will be created and artifacts will be unzip to.
+  echoerr -i the single job to artifacts from.  Overrides -b,-w, and -h
+  echoerr -z decompress and delete the original downloaded artifacts?
+  echoerr -? this message.
+  echoerr output will written in to the -t target directory.
+}
+
+TOKEN=
+HISTORY=
+ARTIFACTS=
+REPO=
+WORKFLOW=
+BRANCH=
+TARGET_DIR=
+WORKFLOW_RUN_ID=
+DECOMPRESS=false
+
+
+while getopts 'h:a:r:w:b:i:t:d:z' OPTION; do
+  case "$OPTION" in
+    h)
+      HISTORY="$OPTARG"
+      ;;
+    a)
+      IFS=' ' read -ra ARTIFACTS <<< "$OPTARG"
+      ;;
+    r)
+      REPO="$OPTARG"
+      ;;
+    w)
+      WORKFLOW="$OPTARG"
+      ;;
+    b)
+      BRANCH="$OPTARG"
+      ;;
+    i)
+      WORKFLOW_RUN_ID="$OPTARG"
+      ;;
+    d)
+      TARGET_DIR="$OPTARG"
+      ;;
+    z)
+      DECOMPRESS="true"
+      ;;
+    t)
+      TOKEN="$OPTARG"
+      ;;
+    ?)
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "${TARGET_DIR}" ]]; then
+  echoerr target directory must be sepecified.
+  usage
+  exit 1
+fi
+
+if [[ -z "${WORKFLOW_RUN_ID}" ]]; then
+  if [[ -z "${BRANCH}" ]] || [[ -z "${WORKFLOW}" ]]; then
+    echoerr 'You must either specify a workflow_run_id (-i), or a branch (-b) and a workflow file (-w).'
+    usage
+    exit 1
+  fi
+fi
+
+# Retry seems to add a lot of time overhead.  Need to look in to this more.
+# curl_attri=("--retry" "3")
+curl_attri=('-H' 'Accept: application/vnd.github.v3+json')
+if [ -n "$TOKEN" ]; then
+  curl_attri+=('-H' "authorization: Bearer ${TOKEN}")
+fi
+echoerr Curl Parameters: "${curl_attri[@]}"
+
+
+# Conditionally retrieves the artifacts from a single jobs, the input parameter which must correspond to a numeric workflow_run_id in github actions
+# and stores the desired artifacts, contained in a list called "ARTIFACTS", in a subdirectory of TARGET_DIR, equal to the workflow_run_id/artifact_name.
+# Artifacts are always zips.   The zip file is downloaded and optionally unziped in to the job's sub directory in the TARGET_DIR, and then deleted.
+# Should the <job dir>/<artifact_name> already exist, no downloads are attempted, as the assumption would be this function has already populated the
+# artifacts in to the job dir.
+#
+# INPUT:
+#  Parameter 1:  A number workflow_run_id
+#
+# ENVIRONMENT:
+#  TARGET_DIR: A root dir for creation of sub directories for each job
+#  ARTIFACTS: A bash array of artifact names to download from github artifacts workflows for this job.
+#  REPO: Github slug corresponding to a repository
+#  UNZIP: unzip and delete the downloaded artifact?
+#
+# SIDE EFFECTS:
+#  The ${TARGET_DIR}/${Parameter 1} dir id populated with the unzipped contents of the artifacts from the job.
+#
+getArtifactsFromJob() {
+  jobId=$1;
+  echoerr getting artifacts for jobId "$jobId"
+  artifact_info="$(curl "${curl_attri[@]}" "https://api.github.com/repos/${REPO}/actions/runs/${jobId}/artifacts"  2>/dev/null)"
+  for artifact_name in "${ARTIFACTS[@]}"; do
+    if [ ! -d "${TARGET_DIR}/${jobId}/${artifact_name}" ]; then
+      mkdir -p "${TARGET_DIR}/${jobId}/${artifact_name}"
+      download_url_str="$(echo "$artifact_info" | jq '.artifacts[] | select(.name=="'"${artifact_name}"'") .archive_download_url')"
+      if [ -n "$download_url_str" ] && [ "$download_url_str" != "null" ]; then
+        download_url="${download_url_str//\"/}"
+        curl -L "${curl_attri[@]}" "$download_url" -o "${TARGET_DIR}/${jobId}/${artifact_name}/${artifact_name}.zip" 2>/dev/null
+        if [ "$DECOMPRESS" = "true" ]; then
+          unzip -q "${TARGET_DIR}/${jobId}/${artifact_name}/${artifact_name}.zip" -d "${TARGET_DIR}/${jobId}/${artifact_name}/"
+          rm "${TARGET_DIR}/${jobId}/${artifact_name}/${artifact_name}.zip"
+        fi
+      else
+        echoerr Artifact not found on workflow run: "${jobId}" with contents:
+        echoerr "$artifact_info"
+      fi
+    fi
+  done
+  echoerr fetched:
+  echoerr "$(ls -d "${TARGET_DIR}/${jobId}/"*/*)"
+}
+
+#
+# Given a REPO, WORKFLOW and (optional) BRANCH, get HISTORY number of prior run artifacts return output workflow_run_ids, one per line.
+#
+getWorkflow_Run_Ids() {
+  #Always using temp files for curl output to prevent shell mangling.
+  tmpfile=$(mktemp /tmp/get_reports.XXXXXX)
+  PARAMETERS=
+  if [ -n "$BRANCH" ]; then
+    PARAMETERS="branch=${BRANCH}&"
+  fi
+  curl "${curl_attri[@]}" "https://api.github.com/repos/${REPO}/actions/workflows/${WORKFLOW}/runs?${PARAMETERS}status=completed&per_page=${HISTORY}" 2>/dev/null > "$tmpfile"
+  workflow_ids="$(jq '.workflow_runs[].id' < "$tmpfile")"
+  echo "${workflow_ids}"
+}
+
+workflow_run_ids=
+if [ -n "$WORKFLOW_RUN_ID" ]; then
+  workflow_run_ids="$WORKFLOW_RUN_ID"
+else
+  workflow_run_ids=$(getWorkflow_Run_Ids)
+fi
+echoerr Workflow Ids:
+echoerr "$workflow_run_ids"
+echo "$workflow_run_ids" | while read -r line; do
+  getArtifactsFromJob "$line"
+done

--- a/get-artifacts/get_artifacts.sh
+++ b/get-artifacts/get_artifacts.sh
@@ -92,9 +92,9 @@ if [[ -z "${WORKFLOW_RUN_ID}" ]]; then
   fi
 fi
 
-curl_attri=("--retry" "3")
-curl_attri+=("--silent")
-curl_attri+=("--show-error")
+curl_attri=('--retry' '3')
+curl_attri+=('--silent')
+curl_attri+=('--show-error')
 curl_attri+=('-H' 'Accept: application/vnd.github.v3+json')
 if [ -n "$TOKEN" ]; then
   curl_attri+=('-H' "authorization: Bearer ${TOKEN}")
@@ -113,20 +113,20 @@ echoerr Curl Parameters: "${curl_attri[@]}"
 # or as unzipped files.
 #
 # INPUT:
-#  Parameter 1:  A number workflow_run_id
+#  Parameter 1:  A number, workflow_run_id
 #
 # ENVIRONMENT:
-#  TARGET_DIR: A root dir for creation of sub directories for each job
-#  ARTIFACTS: A bash array of artifact names to download from github artifacts workflows for this job.
-#  REPO: Github slug corresponding to a repository
-#  UNZIP: unzip and delete the downloaded artifact?
+#  TARGET_DIR: A root dir for creation of sub directories for each workflow.
+#  ARTIFACTS: A bash array of artifact names to download from github workflows.
+#  REPO: Github slug corresponding to a repository.
+#  UNZIP: unzip and delete the downloaded artifact.
 #
 # SIDE EFFECTS:
 #  The ${TARGET_DIR}/${Parameter 1} dir id populated with the unzipped contents of the artifacts from the job.
 #
 function get_artifacts_from_workflow() {
   workflow_run_id=$1;
-  echoerr getting artifacts for jobId "$workflow_run_id"
+  echoerr getting artifacts for workflow_run_id "$workflow_run_id"
   artifact_info="$( curl "${curl_attri[@]}" "https://api.github.com/repos/${REPO}/actions/runs/${workflow_run_id}/artifacts" )"
   for artifact_name in "${ARTIFACTS[@]}"; do
     if [ ! -d "${TARGET_DIR}/${workflow_run_id}/${artifact_name}" ]; then

--- a/get-artifacts/get_artifacts.sh
+++ b/get-artifacts/get_artifacts.sh
@@ -9,12 +9,12 @@ function echoerr() {
 
 # Check prerequisites.
 function check_command() {
-    for var in "$@"; do
-      if ! (command -v "$var" >/dev/null 2>&1); then
-          echoerr "This command requires $var to be installed"
-          exit 1
-      fi
-    done
+  for var in "$@"; do
+    if ! (command -v "$var" >/dev/null 2>&1); then
+      echoerr "This command requires $var to be installed"
+      exit 1
+    fi
+  done
 }
 check_command jq curl zip echo getopts
 
@@ -125,14 +125,14 @@ echoerr Curl Parameters: "${curl_attri[@]}"
 function get_artifacts_from_workflow() {
   workflow_run_id=$1;
   echoerr getting artifacts for jobId "$workflow_run_id"
-  artifact_info="$(curl "${curl_attri[@]}" "https://api.github.com/repos/${REPO}/actions/runs/${workflow_run_id}/artifacts"  2>/dev/null)"
+  artifact_info="$( curl -s -S "${curl_attri[@]}" "https://api.github.com/repos/${REPO}/actions/runs/${workflow_run_id}/artifacts" )"
   for artifact_name in "${ARTIFACTS[@]}"; do
     if [ ! -d "${TARGET_DIR}/${workflow_run_id}/${artifact_name}" ]; then
       mkdir -p "${TARGET_DIR}/${workflow_run_id}/${artifact_name}"
       download_url_str="$(echo "$artifact_info" | jq '.artifacts[] | select(.name=="'"${artifact_name}"'") .archive_download_url')"
       if [ -n "$download_url_str" ] && [ "$download_url_str" != "null" ]; then
         download_url="${download_url_str//\"/}"
-        curl -L "${curl_attri[@]}" "$download_url" -o "${TARGET_DIR}/${workflow_run_id}/${artifact_name}/${artifact_name}.zip" 2>/dev/null
+        curl -L -s -S "${curl_attri[@]}" "$download_url" -o "${TARGET_DIR}/${workflow_run_id}/${artifact_name}/${artifact_name}.zip"
         if [ "$DECOMPRESS" = "true" ]; then
           unzip -q "${TARGET_DIR}/${workflow_run_id}/${artifact_name}/${artifact_name}.zip" -d "${TARGET_DIR}/${workflow_run_id}/${artifact_name}/"
           rm "${TARGET_DIR}/${workflow_run_id}/${artifact_name}/${artifact_name}.zip"
@@ -157,9 +157,10 @@ function get_workflow_run_ids() {
   if [ -n "$BRANCH" ]; then
     PARAMETERS="branch=${BRANCH}&"
   fi
-  curl "${curl_attri[@]}" "https://api.github.com/repos/${REPO}/actions/workflows/${WORKFLOW}/runs?${PARAMETERS}status=completed&per_page=${HISTORY}" 2>/dev/null > "$tmpfile"
+  curl -s -S "${curl_attri[@]}" "https://api.github.com/repos/${REPO}/actions/workflows/${WORKFLOW}/runs?${PARAMETERS}status=completed&per_page=${HISTORY}" > "$tmpfile"
   workflow_ids="$(jq '.workflow_runs[].id' < "$tmpfile")"
   echo "${workflow_ids}"
+  rm "$tmpfile"
 }
 
 workflow_run_ids=

--- a/get-artifacts/get_artifacts.sh
+++ b/get-artifacts/get_artifacts.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+
+# fast fail.
+set -eo pipefail
+
 function echoerr() {
   cat <<< "$@" 1>&2;
 }
@@ -88,9 +92,8 @@ if [[ -z "${WORKFLOW_RUN_ID}" ]]; then
   fi
 fi
 
-# Retry seems to add a lot of time overhead.  Need to look in to this more.
-# curl_attri=("--retry" "3")
-curl_attri=('-H' 'Accept: application/vnd.github.v3+json')
+curl_attri=("--retry" "3")
+curl_attri+=('-H' 'Accept: application/vnd.github.v3+json')
 if [ -n "$TOKEN" ]; then
   curl_attri+=('-H' "authorization: Bearer ${TOKEN}")
 fi


### PR DESCRIPTION
Tested here: https://github.com/rexhoffman/actions/actions/runs/787117755

This action lets you download up to 100 prior builds worth of artifacts in to a standard structure and unzip them.
It will not re download any artifacts that it has already grabbed, making it work well with between build caching and if a job fails/doesn't run -- by downloading missing data if a cache is partially populated.