### PR TITLE
more robust mechanism to find the line stating what pr bors is closing, broken by dependabot.

### DIFF
--- a/changes/get_pr_info.sh
+++ b/changes/get_pr_info.sh
@@ -120,7 +120,7 @@ $DEBUG && echoerr BASE_GITHASH="$BASE_GITHASH"
 #Bor's target branch -- use bors commit message as source of truth.
 if [[ "$BORS" == true ]] &&  [[ "$BRANCH" == "auto" || "$BRANCH" == "canary" ]] ; then
   commit_message=$(git log -1 --pretty=%B)
-  PR_NUMBER=$(echo "${commit_message}" | tail -1 | sed 's/Closes: #//')
+  PR_NUMBER=$(echo "${commit_message}" | grep 'Closes: #' | tail -1 | sed 's/Closes: #//')
 else
   #Let's see if this is a pr.
   #If github actions


### PR DESCRIPTION
Usually commit messages from bors look like:

```
Bumps archlinux from base-devel-20210523.0.23638 to base-devel-20210613.0.25781.

Closes: #8544
```

But bors + dependabot now give us this:

```
Bumps archlinux from base-devel-20210523.0.23638 to base-devel-20210613.0.25781.

Closes: #8544

---
updated-dependencies:
- dependency-name: archlinux
  dependency-type: direct:production
...

Signed-off-by: dependabot[bot] <support@github.com>
```

Works around the issue with grep.   No idea what to do if we have multiple 'Closes' lines.

But....  there are cherry-pick prs produced by bors that have commit messages that look like this:

```
    [GHA] Added build-images step into ci-test workflow
    Closes: #7821
    [GHA] Merge LBT workflow into ci-test
    Closes: #7856
    [GHA]unify LBT switch job into LBT
    Closes: #7939

Closes: #7997
```

So keeping the tail -1