### PR TITLE
Fix test-download-artifacts.yml and use/verify relative paths

### DIFF
--- a/.github/workflows/test-download-artifacts.yml
+++ b/.github/workflows/test-download-artifacts.yml
@@ -22,6 +22,8 @@ jobs:
           workflow_run_id: ${{ github.event.workflow_run.id }}
           artifacts: test.download
           # the following two lines are default values included for clarity.
+          # important to note that all paths are relative to the ${{ github.workspace }}, which is of the form:
+          # /home/runner/work/<org>/<repo>/
           target_dir: ./downloads/
           decompress: true
       - name: Test that "test.download" got downloaded

--- a/.github/workflows/test-download-artifacts.yml
+++ b/.github/workflows/test-download-artifacts.yml
@@ -22,15 +22,15 @@ jobs:
           workflow_run_id: ${{ github.event.workflow_run.id }}
           artifacts: test.download
           # the following two lines are default values included for clarity.
-          target_dir: ${{ github.workspace }}/downloads
+          target_dir: ./downloads/
           decompress: true
       - name: Test that "test.download" got downloaded
         run: |
-          [[ -f  ${{ github.workspace }}/downloads/${{ github.event.workflow_run.id }}/artifacts/test.download/test-file.download ]]
-          [ $( ls ${{ github.workspace }}/downloads/ | wc -l ) = 1 ]
+          [[ -f  ./downloads/${{ github.event.workflow_run.id }}/artifacts/test.download/test-file.download ]]
+          [ $( ls downloads/ | wc -l ) = 1 ]
       - name: Test that "test.not-download" did not get downloaded
         run: |
-          [[ ! -f  ${{ github.workspace }}/downloads/${{ github.event.workflow_run.id }}/artifacts/test.not-download/test-file.not-download ]]
+          [[ ! -f  ./downloads/${{ github.event.workflow_run.id }}/artifacts/test.not-download/test-file.not-download ]]
 
   test-get-artifacts-multiple:
     runs-on: ubuntu-latest
@@ -47,8 +47,11 @@ jobs:
           branch: master
           # follow line is a default value included for clarity.
           history: 10
+      - name: Test the last push to master resulted in artifacts
+        run: |
+          [[ -f ./downloads/${{ github.event.workflow_run.id }}/artifacts/test.download/test-file.download ]]
+          [[ -f ./downloads/${{ github.event.workflow_run.id }}/artifacts/test.not-download/test-file.not-download ]]
+        if: ${{ github.event.workflow_run.head_branch == 'master' }}
       - name: Test that multiple workflow run's files got downloaded
         run: |
-          [[ -f ${{ github.workspace }}/downloads/${{ github.event.workflow_run.id }}/artifacts/test.download/test-file.download ]]
-          [[ -f ${{ github.workspace }}/downloads/${{ github.event.workflow_run.id }}/artifacts/test.not-download/test-file.not-download ]]
           [ $( ls ${{ github.workspace }}/downloads/ | wc -l ) -gt 1 ]


### PR DESCRIPTION
This fixes a test in test-downloaded-artifacts.   When a pr triggers test-downloaded-artifacts today the history of the master branch is downloaded but the pr's test artifacts aren't in it.    Hence a failure.   Split the check in two.   Verify multiple directories are created from prior downloads always, but only check that the specific trigger of this workflow's artifacts are included if the branch triggering the build is the master branch.

Tested in my fork with the new workflow in the master branch (so it get's picked up from a pr) here...
https://github.com/rexhoffman/actions/runs/3011687146?check_suite_focus=true -- notice the skipped test.

And on master here:
https://github.com/rexhoffman/actions/runs/3011637774?check_suite_focus=true -- notice the non-skipped test.

Also choosing to use relative paths as a test to help fix diem/diem, turns out they are always relative to the workspace's root.